### PR TITLE
Features/iteration 5

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,7 @@ viewSavedCoversButton.addEventListener('click', changeToSavedCovers);
 homeButton.addEventListener('click', goHome)
 makeMyBook.addEventListener('click', makeBookCover)
 saveCoverButton.addEventListener('click', saveCoverData)
-savedCoverViewer.addEventListener('click', deleteCover)
+savedCoverViewer.addEventListener('dblclick', deleteCover)
 window.addEventListener('load', randomCover)
 
 function getRandomIndex(array) {
@@ -128,13 +128,12 @@ function showSavedCovers(savedCovers) {
     }
 }
 
-function deleteCover(event) {
-  var tar = event.target.parentElement.id
-  console.log (typeof tar)
-  console.log(typeof savedCovers[0].id)
+function deleteCover() {
+  var coverToBeRemoved = event.target.parentElement.id
   for (var i = 0; i < savedCovers.length; i++) {
-    if (tar == savedCovers[i].id) {
+    if (coverToBeRemoved == savedCovers[i].id) {
       savedCovers.splice(i, 1)
+      changeToSavedCovers()
     }
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -129,6 +129,12 @@ function showSavedCovers(savedCovers) {
 }
 
 function deleteCover(event) {
-  var tar = event.target.parentElement
-  console.log(tar)
+  var tar = event.target.parentElement.id
+  console.log (typeof tar)
+  console.log(typeof savedCovers[0].id)
+  for (var i = 0; i < savedCovers.length; i++) {
+    if (tar == savedCovers[i].id) {
+      console.log('yes')
+    }
+  }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -134,7 +134,7 @@ function deleteCover(event) {
   console.log(typeof savedCovers[0].id)
   for (var i = 0; i < savedCovers.length; i++) {
     if (tar == savedCovers[i].id) {
-      console.log('yes')
+      savedCovers.splice(i, 1)
     }
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,7 @@ viewSavedCoversButton.addEventListener('click', changeToSavedCovers);
 homeButton.addEventListener('click', goHome)
 makeMyBook.addEventListener('click', makeBookCover)
 saveCoverButton.addEventListener('click', saveCoverData)
+savedCoverViewer.addEventListener('click', deleteCover)
 window.addEventListener('load', randomCover)
 
 function getRandomIndex(array) {
@@ -126,4 +127,9 @@ function showSavedCovers(savedCovers) {
         </section>
       </section>`
     }
+}
+
+function deleteCover(event) {
+  var tar = event.target.parentElement
+  console.log(tar)
 }

--- a/src/main.js
+++ b/src/main.js
@@ -56,7 +56,6 @@ function randomCover(){
    makeCurrentCover([randomCover, randomTitle, randomDescOne, randomDescTwo])
    currentCover = new Cover(randomCover, randomTitle, randomDescOne, randomDescTwo)
 }
-//randomCover()
 
 function goHome() {
   changePage(1)

--- a/src/main.js
+++ b/src/main.js
@@ -117,8 +117,7 @@ function showSavedCovers(savedCovers) {
       savedCoverViewer.innerHTML = ''
       for (i = 0; i < savedCovers.length; i++) {
       savedCoverViewer.innerHTML += `
-        <section id="${savedCovers[i].id}">
-        <section class="mini-cover">
+        <section class="mini-cover" id="${savedCovers[i].id}">
           <img class="cover-image" src="${savedCovers[i].cover}">
           <h2 class="cover-title">${savedCovers[i].title}</h2>
           <h3 class="tagline">A tale of <span class="tagline-1">${savedCovers[i].tagline1}</span> and <span class="tagline-2">${savedCovers[i].tagline2}</span></h3>


### PR DESCRIPTION
# Feature to Delete Cover with minor fix to showSavedCovers function
## Delete Cover Function
* When in saved covers section if you double click an image it will disappear from the page
* Page will reload upon double click
## Minor showSavedCovers adjustment
* Moved savedCovers.id to class .mini-cover element as I was having a hard time accessing the element when it was not part of the parent element

## DeleteCover function
*  Variable assigned to an event listener for a target property
*  Variable returns the parent element id
*  For loop created to splice that element out of the savedCovers array
* Utilizing loosely equal comparison operator since one variable returns string and the other returns a number
* changeTosavedCovers function invoked to refresh page with new array
## Testing 
* Save multiple covers and click the 'View Saved Covers' button
* Click the image once to ensure it does not delete
* Double click to delete
* Page should reload


![iteration-5](https://user-images.githubusercontent.com/72312636/102021491-5eefb800-3d3d-11eb-9d2b-a1500e17f2ca.gif)
